### PR TITLE
Gracefully handle case where empty field is slugified

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports.transform = ({ data, debug, log, options }) => {
       return result.concat(writer);
     } catch (error) {
       const objectDetails =
-        object.__metadata && object.__metadata.id
+        object && object.__metadata && object.__metadata.id
           ? ` (Object ID: ${object.__metadata.id})`
           : "";
 


### PR DESCRIPTION
Currently, when `utils.slugify()` is used on an empty field, the operation fails with an error message that is not very clear. This PR changes that, so that the following is shown:

```
eduardoboucas@eduardo robust-avocado % sourcebit fetch
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkVT)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkZX)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkbZ)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkdb)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkfd)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkhf)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkjh)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLklj)
```